### PR TITLE
feat: WB-2688, allow themes for non-connected users

### DIFF
--- a/src/ts/rights/Service.ts
+++ b/src/ts/rights/Service.ts
@@ -117,7 +117,7 @@ export class RightService {
         )
       );
     } catch (e) {
-      console.error(e);
+      console.error(`Unexpected error ${e} in sessionHasResourceRight()`);
       return false;
     }
   }
@@ -215,7 +215,7 @@ export class RightService {
         )
       );
     } catch (e) {
-      console.error(e);
+      console.error(`Unexpected error ${e} in sessionHasWorkflowRight()`);
       return false;
     }
   }
@@ -241,7 +241,7 @@ export class RightService {
           );
       }
     } catch (e) {
-      console.error(e);
+      console.error(`Unexpected error ${e} in sessionHasWorkflowRights()`);
       for (const expect of expects) {
         result[expect] = false;
       }

--- a/src/ts/session/Service.ts
+++ b/src/ts/session/Service.ts
@@ -101,6 +101,9 @@ export class SessionService {
   async latestQuotaAndUsage(
     user: IUserInfo | undefined,
   ): Promise<IQuotaAndUsage> {
+    const defaultQuota = { quota: 0, storage: 0 };
+    if (!user) return defaultQuota;
+
     try {
       const infos = await this.http.get<IQuotaAndUsage>(
         `/workspace/quota/user/${user?.userId}`,
@@ -108,7 +111,7 @@ export class SessionService {
       return infos;
     } catch (error) {
       console.error(error);
-      return { quota: 0, storage: 0 };
+      return defaultQuota;
     }
   }
 
@@ -159,7 +162,7 @@ export class SessionService {
     );
     if (response.status < 200 || response.status >= 300) {
       // Backend tries to redirect the user => not logged in !
-      throw ERROR_CODE.NOT_LOGGED_IN;
+      return;
     } else {
       return value;
     }
@@ -182,7 +185,9 @@ export class SessionService {
 
   private async loadDescription(
     user: IUserInfo | undefined,
-  ): Promise<IUserDescription> {
+  ): Promise<Partial<IUserDescription>> {
+    if (!user) return {};
+
     try {
       const [data, userbook] = await Promise.all([
         // FIXME The full user's description should be obtainable from a single endpoint in the backend.
@@ -195,11 +200,14 @@ export class SessionService {
       return { ...data, ...userbook };
     } catch (error) {
       console.error(error);
-      return {} as unknown as IUserDescription;
+      return {};
     }
   }
 
   private async getBookmarks(user: IUserInfo | undefined) {
+    // Not logged-in users have no bookmarks.
+    if (!user) return [];
+
     const data = await this.http.get("/userbook/preference/apps");
 
     if (!data.preference) {
@@ -242,7 +250,7 @@ export class SessionService {
     );
     if (response.status < 200 || response.status >= 300) {
       // Backend tries to redirect the user => not logged in !
-      throw ERROR_CODE.NOT_LOGGED_IN;
+      return ["Guest"];
     } else {
       return value.result[0].type;
     }

--- a/src/ts/session/interfaces.ts
+++ b/src/ts/session/interfaces.ts
@@ -328,10 +328,10 @@ export interface IMfaCodeState {
 }
 
 export interface IGetSession {
-  user: IUserInfo | undefined;
-  currentLanguage: string | undefined;
+  user?: IUserInfo;
+  currentLanguage?: string;
   quotaAndUsage: IQuotaAndUsage;
-  userDescription: IUserDescription;
+  userDescription: Partial<IUserDescription>;
   userProfile?: UserProfile;
   bookmarkedApps: IWebApp[];
 }


### PR DESCRIPTION
Une page HTML publique nécessite de charger un thème par défaut.
Or, l'implémentation actuelle des services de theming dans `configure` rendait une session utilisateur obligatoire pour pouvoir charger un thème.

Une évolution est donc obligatoire : 
* gestion des cas où le `user` est `undefined`,
* gestion des cas où le backend renvoie une erreur HTTP 302,
* gestion du chargement d'un thème par défaut pour un utilisateur non-connecté => on prend le premier theme trouvé,
* retour d'une valeur par défaut pour les services dont on sait que le backend ne renverra pas de données utiles,
* logs en console plus explicites en cas d'erreur non-gérée.