### PR TITLE
feat(data): #WB-2606, support TEXT_AND_SPEECH events tracking

### DIFF
--- a/src/ts/data/Service.ts
+++ b/src/ts/data/Service.ts
@@ -116,4 +116,14 @@ export class DataService {
 
     this.trackWebEvent(eventData);
   }
+
+  public trackSpeechAndText(direction: "STT" | "TTS") {
+    const eventData = this.addUserInfos({
+      "event-type": "SPEECH_AND_TEXT",
+      function: direction,
+    });
+    if (this.app) eventData["module"] = this.app;
+
+    this.trackWebEvent(eventData);
+  }
 }

--- a/src/ts/data/Service.ts
+++ b/src/ts/data/Service.ts
@@ -3,7 +3,7 @@ import { EVENT_NAME, IDataTrackEvent, LAYER_NAME } from "../notify/interfaces";
 import { IOdeServices } from "../services/OdeServices";
 import { IUserInfo, UserProfile } from "../session/interfaces";
 import { WebBroker } from "./WebBroker";
-import { DataServiceProps, IEventBroker } from "./interface";
+import { DataServiceProps, IDataService, IEventBroker } from "./interface";
 
 /** A data event. */
 type IDataEvent = IDataTrackEvent["data"];
@@ -13,7 +13,7 @@ export interface PublicConfForDataService {
   "data-service"?: DataServiceProps;
 }
 
-export class DataService {
+export class DataService implements IDataService {
   private _webBroker?: IEventBroker;
   private app?: App;
   private user?: IUserInfo;
@@ -28,6 +28,7 @@ export class DataService {
     return this.odeServices.notify();
   }
 
+  // This method is called once, by the service container.
   public async initialize() {
     try {
       // Wait for the app to initialize

--- a/src/ts/data/interface.ts
+++ b/src/ts/data/interface.ts
@@ -1,5 +1,50 @@
-/** Joker value to send all events. */
+/** Joker value to permit sending all events. */
 export const SEND_ALL = "*";
+
+/** Data tracking service. */
+export interface IDataService {
+  /**
+   * Send a VIDEO_SAVE event to the backend.
+   * @param video_id ID of the workspace's video document.
+   * @param duration Duration of the video, in ms.
+   * @param weight Weight  of the video, in bytes.
+   * @param isCaptation Truthy is the video was captured on the end-user device.
+   * @param url Current URL of the navigator, when video was saved.
+   * @param browser Browser name and version (space-separated)
+   * @param deviceType @see UAParser.getDevice().type => console|mobile|tablet|smarttv|wearable|embedded
+   */
+  trackVideoSave(
+    video_id: string,
+    duration: number,
+    weight: number,
+    isCaptation: boolean,
+    url: string,
+    browser: string,
+    deviceType?: string,
+  ): void;
+
+  /**
+   * Send a VIDEO_READ event to the backend.
+   * @param video_id ID of the workspace's video document.
+   * @param isCaptation Truthy is the video was captured on the end-user device.
+   * @param url Current URL of the navigator, when video is played.
+   * @param browser Browser name and version (space-separated)
+   * @param deviceType @see UAParser.getDevice().type => console|mobile|tablet|smarttv|wearable|embedded
+   */
+  trackVideoRead(
+    video_id: string,
+    isCaptation: boolean,
+    url: string,
+    browser: string,
+    deviceType?: string,
+  ): void;
+
+  /**
+   * Send a SPEECH_AND_TEXT event to the backend.
+   * @param direction speech-to-text (voice recognition) or text-to-speech (voice generation)
+   */
+  trackSpeechAndText(direction: "STT" | "TTS"): void;
+}
 
 /** Public properties of the DataService. */
 export interface DataServiceProps {

--- a/src/ts/services/OdeServices.ts
+++ b/src/ts/services/OdeServices.ts
@@ -20,12 +20,13 @@ import { EmbedderService } from "../embedder/Service";
 import { INotifyFramework, NotifyFrameworkFactory } from "../notify/interfaces";
 import { SnipletsService } from "../resources/SnipletsService";
 import { DataService } from "../data/Service";
+import { IDataService } from "../data/interface";
 
 export interface IOdeServices {
   analytics(): AnalyticsService;
   cache(): CacheService;
   conf(): ConfService;
-  data(): DataService;
+  data(): IDataService;
   directory(): DirectoryService;
   http(): HttpService;
   idiom(): IdiomService;


### PR DESCRIPTION
[Ticket WB-2606](https://edifice-community.atlassian.net/browse/WB-2606)

Marquage de la fonctionnalité de speech-to-text et de text-to-speech.

Dans la continuité du ticket WB-2605, on ajoute ici une fonction `trackSpeechAndText(direction: "STT" | "TTS"): void;` au service dédié au pipeline de données (`data`).
Cette fonction sera utilise côté edifice-ui ensuite.